### PR TITLE
Council meeting deadline quickfix

### DIFF
--- a/src/containers/CouncilMeeting/components/NewCouncilmeetingForm.js
+++ b/src/containers/CouncilMeeting/components/NewCouncilmeetingForm.js
@@ -22,7 +22,7 @@ class NewCouncilmeetingForm extends Component {
         this.state = Object.assign({}, initialState)
     }
 
-    handleChange = (field, event) => {
+    handleChange = field => (event) => {
         const meeting = Object.assign({}, this.state.meeting)
         meeting[field] = event.target.value
         this.setState({ meeting })
@@ -34,9 +34,9 @@ class NewCouncilmeetingForm extends Component {
     };
 
     handleProgrammeChange = (event) => {
-        const programme = this.props.programmes.find(programme =>
-            programme.programmeId === Number(event.target.value)
-            && !this.state.meeting.programmes.find(p => p.programmeId === programme.programmeId)
+        const programme = this.props.programmes.find(prog =>
+            prog.programmeId === Number(event.target.value)
+            && !this.state.meeting.programmes.find(p => p.programmeId === prog.programmeId)
         )
         if (programme) {
             const programmes = [...this.state.meeting.programmes, programme]
@@ -82,7 +82,7 @@ class NewCouncilmeetingForm extends Component {
                                 id="newCouncilmeetingDate"
                                 dateFormat={dateFormat}
                                 selected={this.state.meeting.date}
-                                onChange={date => this.handleDateChange(date)}
+                                onChange={this.handleDateChange}
                             />
                         </div>
                         <div className="field">
@@ -91,7 +91,7 @@ class NewCouncilmeetingForm extends Component {
                                 id="newCouncilmeetingInstructorDeadlineDays"
                                 type="text"
                                 value={this.state.meeting.instructorDeadlineDays}
-                                onChange={event => this.handleChange('instructorDeadlineDays', event)}
+                                onChange={this.handleChange('instructorDeadlineDays')}
                                 placeholder="Days"
                             />
                         </div>
@@ -101,7 +101,7 @@ class NewCouncilmeetingForm extends Component {
                                 id="newCouncilmeetingStudentDeadlineDays"
                                 type="text"
                                 value={this.state.meeting.studentDeadlineDays}
-                                onChange={event => this.handleChange('studentDeadlineDays', event)}
+                                onChange={this.handleChange('studentDeadlineDays')}
                                 placeholder="Days"
                             />
                         </div>

--- a/src/containers/Thesis/components/ThesisCouncilmeetingPicker.js
+++ b/src/containers/Thesis/components/ThesisCouncilmeetingPicker.js
@@ -16,9 +16,10 @@ export default class ThesisCouncilmeetingPicker extends Component {
         if (!councilmeetings)
             return []
 
-        const isInFuture = meeting => moment(meeting.instructorDeadline).isAfter(moment())
+        // Deadline is always at the end of the day, so if day is either same or after, then it's not past the deadline.
+        const isInFuture = meeting => moment(meeting.instructorDeadline).isSameOrAfter(moment(), 'day')
         const formatDate = meeting => moment(meeting.date).format('DD.MM.YYYY')
-        const formatDeadline = meeting => moment(meeting.instructorDeadline).format('HH:mm DD.MM.YYYY')
+        const formatDeadline = meeting => moment(meeting.instructorDeadline).format('23:59 DD.MM.YYYY')
         const isMeetingSelectable = meeting => isInFuture(meeting) && meeting.programmes.includes(programmeId)
 
         const meetings = councilmeetings

--- a/src/containers/Unit/components/ProgrammeSelect.js
+++ b/src/containers/Unit/components/ProgrammeSelect.js
@@ -25,7 +25,8 @@ export default class ProgrammeSelect extends Component {
 
     render() {
         const programmes = this.props.programmes.filter(programme =>
-            !programme.name.includes('Department') === this.state.newUnits
+            !programme.name.includes('Department') === this.state.newUnits &&
+            !programme.name.includes('OLD')
         )
 
         return (


### PR DESCRIPTION
NewCouncilmeetingForm, small refactor. Did not alter functionality.

ThesisCouncilMeetingPicker, made clock-agnostic. As long as the deadline is on the same day, display 23:59 and accept until the end of that day. (moment.isSameOrAfter takes 2nd parameter 'day')

ProgrammeSelect, hide units with "OLD" in their name.